### PR TITLE
explicitly convert type to avoid errors

### DIFF
--- a/modules/ppcp-api-client/src/Entity/PurchaseUnit.php
+++ b/modules/ppcp-api-client/src/Entity/PurchaseUnit.php
@@ -317,8 +317,8 @@ class PurchaseUnit {
 			}
 		}
 
-		$fee_items_total = round( $fee_items_total, 2 );
-		$fee_tax_total   = round( $fee_tax_total, 2 );
+		$fee_items_total = round( (float) $fee_items_total, 2 );
+		$fee_tax_total   = round( (float) $fee_tax_total, 2 );
 
 		if ( 0.0 !== $fee_items_total || 0.0 !== $fee_tax_total ) {
 			return true;

--- a/tests/PHPUnit/Button/Endpoint/CreateOrderEndpointTest.php
+++ b/tests/PHPUnit/Button/Endpoint/CreateOrderEndpointTest.php
@@ -32,7 +32,7 @@ class CreateOrderEndpointTest extends TestCase
     {
         list($payer_factory, $testee) = $this->mockTestee();
 
-        $method = $this->testPrivateMethod(CreateOrderEndpoint::class, 'payer');
+        $method = $this->getProtectedMethodAccessibleReflection(CreateOrderEndpoint::class, 'payer');
         $dataString = wp_json_encode($expectedResult['payer']);
         $dataObj = json_decode(wp_json_encode($expectedResult['payer']));
 
@@ -173,7 +173,7 @@ class CreateOrderEndpointTest extends TestCase
      * @return \ReflectionMethod
      * @throws \ReflectionException
      */
-    protected function testPrivateMethod($class, $method)
+    protected function getProtectedMethodAccessibleReflection($class, $method)
     {
         $reflector = new ReflectionClass($class);
         $method = $reflector->getMethod($method);


### PR DESCRIPTION
<!-- Reference the source of this Pull Request. -->
<!-- Remove any which are not applicable. -->
**Issue**: # part of the [PCP-72](https://inpsyde.atlassian.net/browse/PCP-72).

---

### Description
<!-- Describe the changes made in this Pull Request and the reason for these changes. -->
Explicitly convert the value to `float` before passing to the `round()` function.
Also, rename the helper method in tests so it wouldn't be used by PHPUnit as a test method.

### Steps to test:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->
1. Run PHPUnit tests. There should be no errors.

### Documentation
<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [ ] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation -->

### Changelog entry
> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

* Fix - TypeError because of the incorrect argument type.
* Fix - Tests.
